### PR TITLE
Enhance popup UI with new docs grouping and feature scaffolding

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -13,9 +13,11 @@ body {
   font-family: var(--font-family);
   color: var(--body);
   background: url("../images/bf-avidly theme-hero.png");
-    background-position: bottom center;
-    background-repeat: no-repeat;
-    background-size: cover;
+  background-position: bottom center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  max-height: 490px;
+  height: 490px;
 }
 
 .container {
@@ -29,6 +31,7 @@ body {
   gap: 8px;
   border-bottom: 1px solid var(--primary);
   padding-bottom: 8px;
+  overflow: scroll;
 }
 
 .tab-btn.btn {
@@ -49,19 +52,19 @@ body {
 }
 
 .tab-btn.btn.active {
-background: var(--primary);
-    color: #fff;
-    -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
-    transform-style: preserve-3d;
-    cursor: pointer;
-    overflow: hidden;
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(2px);
+  background: var(--primary);
+  color: #fff;
+  -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
+  transform-style: preserve-3d;
+  cursor: pointer;
+  overflow: visible;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 .tab-content {
@@ -125,24 +128,24 @@ a {
 
 a:hover {
   color: var(--secondary);
-  border: none!important;
+  border: none !important;
 }
 
 #docs a:hover,
 #community a:hover {
-    background: var(--primary);
-    color: #fff;
-    -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.1)!important;
-    box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
-    transform-style: preserve-3d;
-    cursor: pointer;
-    overflow: hidden;
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(2px);
+  background: var(--primary);
+  color: #fff;
+  -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
+  transform-style: preserve-3d;
+  cursor: pointer;
+  overflow: hidden;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 .btn {
@@ -162,8 +165,8 @@ a:hover {
 .btn-1,
 .btn-2 {
   background: transparent;
-    border: 1px solid var(--secondary);
-    color: var(--primary);
+  border: 1px solid var(--secondary);
+  color: var(--primary);
 }
 
 .btn-1 {
@@ -193,16 +196,16 @@ input[disabled] {
 .button-grid button {
   width: 100%;
   height: auto;
-  transition: .3s ease-in-out;
+  transition: 0.3s ease-in-out;
   padding: 10px;
   padding-right: 10px;
-    padding-left: 10px;
+  padding-left: 10px;
 }
 
 .button-grid button:hover {
-background: rgba(255, 255, 255, 0.08);
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(2px);
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 .language-selector {
@@ -222,7 +225,7 @@ background: rgba(255, 255, 255, 0.08);
   background: #fff;
   color: var(--dark);
   font-family: var(--font-family);
-      background: transparent;
+  background: transparent;
 }
 
 .message {
@@ -235,18 +238,18 @@ background: rgba(255, 255, 255, 0.08);
   border-radius: 4px;
   margin-top: 8px;
   background: var(--primary);
-    color: #fff;
-    -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
-    transform-style: preserve-3d;
-    cursor: pointer;
-    overflow: hidden;
-    backdrop-filter: blur(2px);
-    -webkit-backdrop-filter: blur(2px);
+  color: #fff;
+  -webkit-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  -moz-box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  box-shadow: 0 10px 32px 0 rgba(1, 66, 97, 0.11);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 15px 30px -12px rgba(0, 0, 0, 0.5);
+  transform-style: preserve-3d;
+  cursor: pointer;
+  overflow: hidden;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 /* Apply button styles to all buttons */

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -175,6 +175,13 @@ a:hover {
   font-size: 0.75rem;
 }
 
+button[disabled],
+select[disabled],
+input[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .button-grid {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -6,15 +6,30 @@ document.addEventListener("DOMContentLoaded", () => {
   tabs.forEach((tab) => {
     tab.addEventListener("click", () => {
       // Remove active class from all tabs and contents
-      tabs.forEach((t) => t.classList.remove("active"));
+      tabs.forEach((t) => {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+      });
       contents.forEach((c) => c.classList.remove("active"));
 
       // Add active class to clicked tab and corresponding content
       tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
       const tabId = tab.getAttribute("data-tab");
       document.getElementById(tabId).classList.add("active");
     });
   });
+
+  const initDisabledTooltips = () => {
+    const disabledElements = document.querySelectorAll("button[disabled], select[disabled], input[disabled]");
+    disabledElements.forEach((el) => {
+      if (!el.getAttribute("title")) {
+        el.setAttribute("title", "Coming soon");
+      }
+    });
+  };
+
+  initDisabledTooltips();
 
   // URL modification functionality
   const modifyUrl = async (params) => {

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,12 +9,16 @@
 <body>
     <div class="container">
         <div class="tabs">
-            <button class="tab-btn btn btn-1 active" data-tab="dev-tools">Tools</button>
-            <button class="tab-btn btn btn-1" data-tab="docs">Documentation</button>
-            <button class="tab-btn btn btn-1" data-tab="community">Community</button>
+            <button class="tab-btn btn btn-1 active" data-tab="dev-tools" id="dev-tools-tab" aria-selected="true" aria-controls="dev-tools">Tools</button>
+            <button class="tab-btn btn btn-1" data-tab="docs" id="docs-tab" aria-selected="false" aria-controls="docs">Documentation</button>
+            <button class="tab-btn btn btn-1" data-tab="community" id="community-tab" aria-selected="false" aria-controls="community">Community &amp; Support</button>
+            <button class="tab-btn btn btn-1" data-tab="utilities" id="utilities-tab" aria-selected="false" aria-controls="utilities">Utilities</button>
+            <button class="tab-btn btn btn-1" data-tab="testing" id="testing-tab" aria-selected="false" aria-controls="testing">Testing</button>
+            <button class="tab-btn btn btn-1" data-tab="debug" id="debug-tab" aria-selected="false" aria-controls="debug">Debug</button>
+            <button class="tab-btn btn btn-1" data-tab="updates" id="updates-tab" aria-selected="false" aria-controls="updates">Updates</button>
         </div>
 
-        <div class="tab-content active" id="dev-tools">
+        <div class="tab-content active" id="dev-tools" role="tabpanel" aria-labelledby="dev-tools-tab">
             <div class="button-grid section">
                 <button class="btn btn-2" id="bypassCache">Clear Cache</button>
                 <button class="btn btn-2" id="activateDev">Enable Developer Mode</button>
@@ -34,27 +38,74 @@
             </div>
         </div>
 
-        <div class="tab-content" id="docs">
+        <div class="tab-content" id="docs" role="tabpanel" aria-labelledby="docs-tab">
             <div class="section">
-                <h3>API Documentation</h3>
+                <h3>Core Development</h3>
                 <a href="https://developers.hubspot.com/docs/api/overview" target="_blank">CRM API Reference</a>
                 <a href="https://developers.hubspot.com/docs/cms/overview" target="_blank">CMS Developer Docs</a>
+                <a href="https://developers.hubspot.com/docs/cms/hubl" target="_blank">HubL Documentation</a>
+            </div>
+            <div class="section">
+                <h3>Integrations &amp; Auth</h3>
                 <a href="https://developers.hubspot.com/docs/api/webhooks" target="_blank">Webhooks Guide</a>
                 <a href="https://developers.hubspot.com/docs/api/oauth-quickstart" target="_blank">OAuth Overview</a>
             </div>
+        </div>
+
+        <div class="tab-content" id="community" role="tabpanel" aria-labelledby="community-tab">
             <div class="section">
-                <h3>Template Language</h3>
-                <a href="https://developers.hubspot.com/docs/cms/hubl" target="_blank">HubL Documentation</a>
+                <h3>Community &amp; Support</h3>
+                <a href="https://community.hubspot.com/t5/Developer-Forum/ct-p/developers" target="_blank">Developer Announcements</a>
+                <a href="https://community.hubspot.com/t5/CMS-Development/bd-p/cms-development" target="_blank">CMS Development Tips</a>
+                <a href="https://community.hubspot.com/t5/APIs-Integrations/bd-p/integration-forum" target="_blank">APIs &amp; Integrations Forum</a>
+                <a href="https://community.hubspot.com/t5/Workflows/bd-p/workflows" target="_blank">Workflow Automation Forum</a>
+                <a href="https://community.hubspot.com/t5/HubSpot-Ideas/idb-p/HubSpot_Ideas" target="_blank">HubSpot Ideas (Developer)</a>
+                <a href="https://github.com/HubSpot" target="_blank">Example Repos</a>
+                <a href="https://status.hubspot.com/" target="_blank">Status Page</a>
             </div>
         </div>
 
-        <div class="tab-content" id="community">
+        <div class="tab-content" id="utilities" role="tabpanel" aria-labelledby="utilities-tab">
             <div class="section">
-                <h3>Community Resources</h3>
-                <a href="https://community.hubspot.com/t5/Developer-Forum/ct-p/developers" target="_blank">Developer Announcements</a>
-                <a href="https://community.hubspot.com/t5/CMS-Development/bd-p/cms-development" target="_blank">CMS Development Tips</a>
-                <a href="https://community.hubspot.com/t5/APIs-Integrations/bd-p/integration-forum" target="_blank">CRM Customization Questions</a>
-                <a href="https://community.hubspot.com/t5/Workflows/bd-p/workflows" target="_blank">Workflow Automation Examples</a>
+                <h3>Utilities</h3>
+                <button class="btn btn-2" disabled title="Coming soon">Token Decoder</button>
+                <button class="btn btn-2" disabled title="Coming soon">HMAC Validator</button>
+                <button class="btn btn-2" disabled title="Coming soon">JSON Formatter</button>
+                <button class="btn btn-2" disabled title="Coming soon">Rate Limit Checker</button>
+                <div class="message">Planned feature</div>
+            </div>
+        </div>
+
+        <div class="tab-content" id="testing" role="tabpanel" aria-labelledby="testing-tab">
+            <div class="section">
+                <h3>Portal Switcher</h3>
+                <select disabled>
+                    <option>Sandbox</option>
+                    <option>Production</option>
+                </select>
+                <div class="message">Planned feature</div>
+            </div>
+            <div class="section">
+                <h3>API GET Tester</h3>
+                <input type="text" placeholder="Enter endpoint" disabled />
+                <button class="btn btn-2" disabled title="Coming soon">Send</button>
+                <div class="message">Planned feature</div>
+            </div>
+        </div>
+
+        <div class="tab-content" id="debug" role="tabpanel" aria-labelledby="debug-tab">
+            <div class="section">
+                <h3>Debug</h3>
+                <p>Network/console filters for api.hubspot.com coming soon.</p>
+            </div>
+        </div>
+
+        <div class="tab-content" id="updates" role="tabpanel" aria-labelledby="updates-tab">
+            <div class="section">
+                <h3>Updates</h3>
+                <ul>
+                    <li>HubSpot changelog, breaking-change notices, and RSS integration coming soon.</li>
+                </ul>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- restructure Documentation tab into Core Development and Integrations & Auth sections
- expand Community to "Community & Support" and add utilities/testing/debug/updates tab scaffolding
- improve tab switching logic with ARIA attributes and disabled tooltips

## Testing
- `npm run lint`
- `npm run dev` *(fails: webpack entry src/index.js missing)*

------
https://chatgpt.com/codex/tasks/task_b_68a0dc8b204c83249ae77d8ec925e7d7